### PR TITLE
Arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,8 @@ $ cd py-todo && cp todo /usr/local/bin/
 ## Usage
 ```
 $ todo                        # List all items.
-$ todo -a                     # Add an item.
+$ todo -a                     # Add an item. (with Title prompt)
+$ todo -a <todo item>         # Add an item. (without Title prompt)
 $ todo -r <index>             # Remove an existing item.
 $ todo -h                     # Display help message.
 $ todo -v                     # Display version info.
@@ -51,4 +52,3 @@ $ todo -org <filename>        # Adds TODOs from Emacs org mode
 
 ## License
 Available under the [MIT License](https://github.com/aesophor/py-todo/blob/master/LICENSE)
-

--- a/todo
+++ b/todo
@@ -42,7 +42,6 @@ def add_item(title: str, exp_date: datetime):
 def remove_item(index: int):
     del items[index]
 
-
 def list_items():
     if len(items) > 0:
         print("You have {item_count} item{s} left on the reminder!".format(

--- a/todo
+++ b/todo
@@ -89,9 +89,12 @@ if __name__ == '__main__':
         list_items()
 
     elif sys.argv[1] == '-a' or sys.argv[1] == '--add':
-        title = input("Title: ")
-        exp_date = input("Expiry date (e.g., YYYY/MM/DD) (Optional): ")
+        if len(sys.argv) > 2:
+            title = sys.argv[2]
+        else:
+            title = input("Title: ")
 
+        exp_date = input("Expiry date (e.g., YYYY/MM/DD) (Optional): ")
         if exp_date == '':
             exp_date = None
         else:

--- a/todo
+++ b/todo
@@ -56,7 +56,8 @@ def list_items():
 def print_usage():
     print("")
     print("Usage: ." + sys.argv[0] + " <argument>")
-    print("-a --add                   -- Adds a new item.")
+    print("-a --add                   -- Adds a new item. With Title prompt")
+    print("-a --add <item>            -- Adds a new item. Without Title prompt")
     print("-r --remove <index>        -- Removes an item by index.")
     print("-l --list                  -- Lists all items.")
     print("-org --orgfile <filename>  -- Add org file TODOs.")


### PR DESCRIPTION
added the possibility to create a todo item straight of the commandline.
This way you can even add items faster by parsing it: 
```
todo -a "This is a task"
```
or 
```
todo -a task
```